### PR TITLE
Feedback andres

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,83 @@ The official documentation is currently in development and not available now. We
 
 <https://pysketball.readthedocs.io/en/latest/>
 
+### Dependencies
+
+Before installing the package make sure your working environment complies with the following dependecies:
+
+- Python 3.7
+
+- Pandas 1.0.1 or higher. To install the lastest release of the package via conda-forge channels use:
+
+```sh
+conda install pandas
+```
+or via PyPI:
+
+```sh
+pip install --upgrade pandas
+```
+
+- Pytest 5.3.5 or higher. To install the lastest release of the package via conda-forge channels use:
+
+```sh
+conda install pytest
+```
+
+or via PyPI:
+
+```sh
+pip install --upgrade pytest
+```
+
+- Numpy 1.18.1 or higher. To install the lastest release of the package via conda-forge channels use:
+
+```sh
+conda install numpy
+```
+
+or via PyPI:
+
+```sh
+pip install --upgrade numpy
+```
+
+- Altair 4.0.1. To install this specific realese via conda-forge channels use:
+
+```sh
+conda install altair=4.0.1
+```
+
+or via PyPI:
+ 
+```sh
+pip install --upgrade altair==4.0.1
+```
+
+- Selenium 5.3.5 or higher. To install the lastest realese of this package via conda-forge channels use:
+
+```sh
+conda install selenium
+```
+
+- Request 2.23.0 or higher. To install the lastest realese of this package via conda-forge channels use:
+
+```sh
+conda install requests
+```
+
+or via PyPI:
+
+```sh
+pip install --upgrade requests
+```
+
+- Python-semantic-release 4.10.0 or higher. To install the lastest realese of this package via PyPI use:
+
+```sh
+pip install --upgrade python-semantic-release
+```
+
 ### Usage and Testing Instructions/Requirements
 
 The `pysketball` package uses the Selenium tool as part of its `nba_scraper` function. Thus, it is necessary to install a webdriver for Selenium's automated driver web browsing. 
@@ -118,8 +195,8 @@ With the scraped data in the form of a `pandas.DataFrame` called `nba_2018_regul
 >>> from pysketball.nba_ranking import nba_ranking
 >>> from pysketball.nba_team_stats import nba_team_stats
 >>> # Scrape regular season 2018/19 and return a dataframe while storing it as csv file called "nba_2018_regular.csv"
->>> nba_boxplot(nba_2018_regular, position= "POS", teams= None, stats= "GP")
->>> nba_ranking(nba_2018_regular, 'PLAYER' , 'GP', top = 2, ascending = False, fun = 'mean')
+>>> nba_boxplot(nba_2018_regular, position= 'POS', teams= None, stats= 'GP')
+>>> nba_ranking(nba_2018_regular, 'NAME' , 'GP', top = 2, ascending = False, fun = 'mean')
 >>> nba_team_stats.nba_team_stats(nba_2018_regular, stats_filter = ['GP', '3PM', 'FT%'],teams_filter = ['UTAH', 'PHX', 'DET'],positions_filter = ['C', 'PG'])
 ```
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ whereis chromedriver
 With that, add it to your PATH in your `.bashrc` file for Linux and Mac users.
 
 ```sh
-export PATH="<PATH_TO_CHROMEDRIVER.EXE>:$PATH"
+export PATH="<PATH_TO_CHROMEDRIVER>:$PATH"
 ```
 
 For Windows, please refer to this [article guide for instructions on adding PATH variables](https://helpdeskgeek.com/windows-10/add-windows-path-environment-variable/).

--- a/pysketball/nba_ranking.py
+++ b/pysketball/nba_ranking.py
@@ -63,7 +63,7 @@ def nba_ranking(data, column, by, top=10, ascending=True, fun='mean'):
 
     # The descending argument should be a boolean
     if (fun not in ['sum', 'mean']):
-        raise TypeError("The fun argument should be either var or mean")
+        raise TypeError("The fun argument should be either sum or mean")
 
     # Checks if the column exists in the dataframe
     if column not in data.columns:


### PR DESCRIPTION
Hi guys,

This commit contains the following changes:

- The README.md file was modified to contain information about the dependecies and how to install the correct version of them. This addresses @kvarada's following feedback on issue [#31](https://github.com/UBC-MDS/software-review/issues/31#issuecomment-602124775):

here
>Installation directions might benefit from some clarification. I had to do the following in order to get it working.
>
>`conda install selenium`
`pip install python-semantic-release`

here

> Good that you include the instruction to put the chromedriver path in the system path variable. I guess you do not mean PATH_TO_CHROMEDRIVER.EXE in the following command for Linux and MacOS.
> 
> `export PATH="<PATH_TO_CHROMEDRIVER.EXE>:$PATH"`

and here
>Tests
>When I ran your tests, two tests failed with the following error.
`AttributeError: module 'altair.vegalite' has no attribute 'v4'`

- The README.md file was also modified to have the correct example for the function `nba_ranking`, in order to address @kvarada and @zoepan00 feedback on  issue [#31](https://github.com/UBC-MDS/software-review/issues/31#issuecomment-602124775):

here:

> Step 3 example nba_ranking(nba_2018_regular, 'PLAYER' , 'GP', top = 2, ascending = False, fun = 'mean') is not working

and here:

> In your README, in the following usage example of the function nba_ranking, the 'PLAYER' column is undefined in the scraped CSV and so it gives an error. Replacing it with 'NAME' worked for me.
> nba_ranking(nba_2018_regular, 'PLAYER' , 'GP', top = 2, ascending = False, fun = 'mean')

- `nba_ranking`'s error message was updated to address @zoepan00's feedback on issue [#31](https://github.com/UBC-MDS/software-review/issues/31#issuecomment-601541684): 

> nba_ranking: Error message for fun argument is not updated. Currently it says The fun argument should be either var or mean

Please check everythin is in order,
Thanks,
Andres



